### PR TITLE
Bug Fix: Fix SecurityUtils translation key

### DIFF
--- a/common/src/main/java/dev/masonroot/nora/common/SecurityUtils.java
+++ b/common/src/main/java/dev/masonroot/nora/common/SecurityUtils.java
@@ -73,7 +73,8 @@ public class SecurityUtils {
   public static void throwIfIsNotDirectory(@NonNull final Path file) {
     if (!Files.isDirectory(file)) {
       throw new SecurityException(
-          String.format("%s: %s", Translator.translate("common.exceptions.notDirectory"), file));
+          String.format(
+              "%s: %s", Translator.translate("common.exceptions.pathNotDirectory"), file));
     }
   }
 }


### PR DESCRIPTION
# Bug Fix Pull Request

## Issue Description
Wrong translation key in SecurityUtils#throwIfNotDirectory

## Fix Implemented
I replaced with the right translation key

## Changes Made

1.SecurityUtils

## Testing
Copy/paste never fails

## Related Issues
N/A

## Checklist
- [x] Code follows the project's style guidelines
- [x] All new and existing tests pass
- [ x New unit tests and integration tests were added to prevent regression
- [x] Documentation was updated if necessary
- [x] Any necessary database migrations were included
- [ ] Tests cover at least 90% of the code if applicable.
